### PR TITLE
Cursor line number now shows absolute line number.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,13 @@ let gutter = new Compartment();
 
 function relativeLineNumbers(lineNo: number, state: EditorState) {
   if (lineNo > state.doc.lines) {
-    return "0";
+    return lineNo.toString();
   }
   const cursorLine = state.doc.lineAt(
     state.selection.asSingle().ranges[0].to
   ).number;
   if (lineNo === cursorLine) {
-    return "0";
+    return lineNo.toString();
   } else {
     return Math.abs(cursorLine - lineNo).toString();
   }


### PR DESCRIPTION
Previously cursor line always displayed 0. This change better conforms to the usual relative line number behavior.